### PR TITLE
Remove logging from the healthcheck handler

### DIFF
--- a/cmd/coinjar/main.go
+++ b/cmd/coinjar/main.go
@@ -27,7 +27,7 @@ func newRouter(cfg *coinjar.Config) (router *mux.Router) {
 	}
 
 	router.Handle("/health",
-		handlers.LoggingHandler(os.Stdout, coinjar.HealthCheckHandler())).
+		coinjar.HealthCheckHandler()).
 		Methods("GET")
 
 	router.Handle("/transaction",


### PR DESCRIPTION
The logs are essentially just healthcheck spam. One a minute since forever, so this request is to remove that.